### PR TITLE
Revision of LinkedHashSet class 

### DIFF
--- a/spec/TestLinkedHashMap.spec.ts
+++ b/spec/TestLinkedHashMap.spec.ts
@@ -295,7 +295,7 @@ describe("Test LinkedHashMap functionality", function() {
     expect (values[2]).toEqual(1);
   });
 
-  it ("Test value remove LinkedHashMap entry success", function () {
+  it ("Test value remove entry success", function () {
     const sourceMap:LinkedHashMap<PetStoreProduct,ValueClass> = new LinkedHashMap<PetStoreProduct,ValueClass>();
     expect (sourceMap.put (product1, new ValueClass())).toEqual(undefined);
     expect (sourceMap.put (product2, new ValueClass())).toEqual(undefined);
@@ -320,7 +320,7 @@ describe("Test LinkedHashMap functionality", function() {
     expect (values[1]).toEqual(1);
   });
 
-  it ("Test value remove LinkedHashMap entry failure", function () {
+  it ("Test value remove entry failure", function () {
     const sourceMap:LinkedHashMap<PetStoreProduct,ValueClass> = new LinkedHashMap<PetStoreProduct,ValueClass>();
     expect (sourceMap.put (product1, new ValueClass())).toEqual(undefined);
     expect (sourceMap.put (product2, new ValueClass())).toEqual(undefined);

--- a/spec/TestLinkedHashMap.spec.ts
+++ b/spec/TestLinkedHashMap.spec.ts
@@ -29,8 +29,8 @@ describe("Test LinkedHashMap functionality", function() {
     }
   }
 
-  const product2:PetStoreProduct = new PetStoreProduct("ChewToy", 14.99);
   const product1:PetStoreProduct = new PetStoreProduct("Catnip", 4.99);
+  const product2:PetStoreProduct = new PetStoreProduct("ChewToy", 14.99);
   const product3:PetStoreProduct = new PetStoreProduct("Goldfish", 9.99);
   const productNotAvailable:PetStoreProduct = new PetStoreProduct("Bananas", 1.99);
 
@@ -293,6 +293,41 @@ describe("Test LinkedHashMap functionality", function() {
     expect (values[0]).toEqual(1);
     expect (values[1]).toEqual(1);
     expect (values[2]).toEqual(1);
+  });
+
+  it ("Test value remove LinkedHashMap entry success", function () {
+    const sourceMap:LinkedHashMap<PetStoreProduct,ValueClass> = new LinkedHashMap<PetStoreProduct,ValueClass>();
+    expect (sourceMap.put (product1, new ValueClass())).toEqual(undefined);
+    expect (sourceMap.put (product2, new ValueClass())).toEqual(undefined);
+    expect (sourceMap.put (product3, new ValueClass())).toEqual(undefined);
+    expect (sourceMap.size ()).toEqual(3);
+    expect (sourceMap.remove(product1)).toEqual(new ValueClass());
+
+    let count:number = 0;
+    let values:number[] = [];
+
+    let linkedIter:ValueIterator<PetStoreProduct,ValueClass> = sourceMap.newValueIterator();
+    for (; linkedIter.hasNext(); ) {
+      const p:ValueClass = linkedIter._next();
+      values[count] = p.blah1;
+      count = count + 1;
+    }
+    expect (count).toEqual(2);
+    expect (sourceMap.containsKey(product1)).toEqual(false);
+    expect (sourceMap.containsKey(product2)).toEqual(true);
+    expect (sourceMap.containsKey(product3)).toEqual(true);
+    expect (values[0]).toEqual(1);
+    expect (values[1]).toEqual(1);
+  });
+
+  it ("Test value remove LinkedHashMap entry failure", function () {
+    const sourceMap:LinkedHashMap<PetStoreProduct,ValueClass> = new LinkedHashMap<PetStoreProduct,ValueClass>();
+    expect (sourceMap.put (product1, new ValueClass())).toEqual(undefined);
+    expect (sourceMap.put (product2, new ValueClass())).toEqual(undefined);
+    expect (sourceMap.put (product3, new ValueClass())).toEqual(undefined);
+    expect (sourceMap.size ()).toEqual(3);
+    const product5:PetStoreProduct = new PetStoreProduct("test", 4.99);
+    expect (sourceMap.remove(product5)).toBeNull();
   });
 
   it("Test clear", function() {

--- a/spec/TestLinkedHashSet.spec.ts
+++ b/spec/TestLinkedHashSet.spec.ts
@@ -186,30 +186,38 @@ describe("Test LinkedHashSet functionality", function() {
     expect (values[2]).toEqual("A");
   });
 
-  it("Test remove LinkedHashSet entry", function() {
+  it("Test remove LinkedHashSet entry success", function() {
     // makes new list unorder.. it uses set. see initializeElements() 
     const sourceSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>());
     expect (sourceSet.add ("A")).toEqual(true);
     expect (sourceSet.add ("C")).toEqual(true);
     expect (sourceSet.add ("B")).toEqual(true);
     expect (sourceSet.size ()).toEqual(3);
-    const destinationSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>(), sourceSet);
-    expect (destinationSet.size ()).toEqual(3);
-    destinationSet.remove("B");
+    expect (sourceSet.remove("B")).toEqual(true);
   
     let count:number = 0;
     let values:string[] = [];
 
-    let linkedIter:LinkedIterator<string> = destinationSet.Iterator();
+    let linkedIter:LinkedIterator<string> = sourceSet.Iterator();
     for (; linkedIter.hasNext(); ) {
       const s:string = linkedIter._next();
       values[count] = s;
       count = count + 1;
     }
     expect (count).toEqual(2);
-    expect (destinationSet.contains("C")).toEqual(true);
-    expect (values[0]).toEqual("C");
-    expect (values[1]).toEqual("A");
+    expect (sourceSet.contains("C")).toEqual(true);
+    expect (values[0]).toEqual("A");
+    expect (values[1]).toEqual("C");
+  });
+
+  it("Test remove LinkedHashSet entry failure", function() {
+    // makes new list unorder.. it uses set. see initializeElements() 
+    const sourceSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>());
+    expect (sourceSet.add ("A")).toEqual(true);
+    expect (sourceSet.add ("C")).toEqual(true);
+    expect (sourceSet.add ("B")).toEqual(true);
+    expect (sourceSet.size ()).toEqual(3);
+    expect (sourceSet.remove("D")).toEqual(false);
   });
 
   it("Test clear", function() {

--- a/spec/TestLinkedHashSet.spec.ts
+++ b/spec/TestLinkedHashSet.spec.ts
@@ -6,8 +6,8 @@
 * found in the LICENSE file at https://github.com/larrydiamond/typescriptcollectionsframework/LICENSE
 */
 import {AllFieldHashable} from "../src/AllFieldHashable";
-import {KeyIterator, LinkedHashMap} from "../src/LinkedHashMap";
-import {LinkedHashSet} from "../src/LinkedHashSet";
+import {LinkedHashSet, LinkedIterator, LinkedEntry} from "../src/LinkedHashSet";
+import {JIterator} from "../src/JIterator";
 
 describe("Test LinkedHashSet functionality", function() {
 
@@ -116,51 +116,51 @@ describe("Test LinkedHashSet functionality", function() {
     expect (mySet1.isEmpty ()).toEqual(false);
   });
 
-  it("Test-1 key jiterator three entries", function() {
+  it("Test-1 value jiterator three entries", function() {
     const petStoreSet1:LinkedHashSet<PetStoreProduct> = new LinkedHashSet<PetStoreProduct> (new AllFieldHashable<PetStoreProduct>());
     let count:number = 0;
-    let keys:string[] = [];
+    let values:string[] = [];
 
     petStoreSet1.add (product1);
     petStoreSet1.add (product2);
     petStoreSet1.add (product3);
 
-    let linkedIter:KeyIterator<PetStoreProduct,any> = petStoreSet1.newKeyIterator();
+    let linkedIter:LinkedIterator<PetStoreProduct> = petStoreSet1.Iterator();
     for (; linkedIter.hasNext(); ) {
       const p:PetStoreProduct = linkedIter._next();
-      keys[count] = p.getProductName();
+      values[count] = p.getProductName();
       count = count + 1;
     }
     expect (count).toEqual(3);
     expect (petStoreSet1.contains(product2)).toEqual(true);
-    expect (keys[0]).toEqual("Catnip");
-    expect (keys[1]).toEqual("ChewToy");
-    expect (keys[2]).toEqual("Goldfish");
+    expect (values[0]).toEqual("Catnip");
+    expect (values[1]).toEqual("ChewToy");
+    expect (values[2]).toEqual("Goldfish");
   });
 
-  it("Test-2 key jiterator three entries", function() {
+  it("Test-2 value jiterator three entries", function() {
     const stringSet:LinkedHashSet<string> = new LinkedHashSet<string> (new AllFieldHashable<string>());
     let count:number = 0;
-    let keys:string[] = [];
+    let values:string[] = [];
 
     stringSet.add ("3");
     stringSet.add ("2");
     stringSet.add ("1");
 
-    let linkedIter:KeyIterator<string,any> = stringSet.newKeyIterator();
+    let linkedIter:LinkedIterator<string> = stringSet.Iterator();
     for (; linkedIter.hasNext(); ) {
       const s:string = linkedIter._next();
-      keys[count] = s;
+      values[count] = s;
       count = count + 1;
     }
     expect (count).toEqual(3);
     expect (stringSet.contains("2")).toEqual(true);
-    expect (keys[0]).toEqual("3");
-    expect (keys[1]).toEqual("2");
-    expect (keys[2]).toEqual("1");
+    expect (values[0]).toEqual("3");
+    expect (values[1]).toEqual("2");
+    expect (values[2]).toEqual("1");
   });
 
-  it("Test key jiterator three initial entries", function() {
+  it("Test value jiterator three initial entries", function() {
     // makes new list unorder.. it uses set. see initializeElements() 
     const sourceSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>());
     expect (sourceSet.add ("A")).toEqual(true);
@@ -171,19 +171,45 @@ describe("Test LinkedHashSet functionality", function() {
     expect (destinationSet.size ()).toEqual(3);
 
     let count:number = 0;
-    let keys:string[] = [];
+    let values:string[] = [];
 
-    let linkedIter:KeyIterator<string,any> = destinationSet.newKeyIterator();
+    let linkedIter:LinkedIterator<string> = destinationSet.Iterator();
     for (; linkedIter.hasNext(); ) {
       const s:string = linkedIter._next();
-      keys[count] = s;
+      values[count] = s;
       count = count + 1;
     }
     expect (count).toEqual(3);
     expect (destinationSet.contains("C")).toEqual(true);
-    expect (keys[0]).toEqual("C");
-    expect (keys[1]).toEqual("B");
-    expect (keys[2]).toEqual("A");
+    expect (values[0]).toEqual("C");
+    expect (values[1]).toEqual("B");
+    expect (values[2]).toEqual("A");
+  });
+
+  it("Test remove LinkedHashSet entry", function() {
+    // makes new list unorder.. it uses set. see initializeElements() 
+    const sourceSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>());
+    expect (sourceSet.add ("A")).toEqual(true);
+    expect (sourceSet.add ("C")).toEqual(true);
+    expect (sourceSet.add ("B")).toEqual(true);
+    expect (sourceSet.size ()).toEqual(3);
+    const destinationSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>(), sourceSet);
+    expect (destinationSet.size ()).toEqual(3);
+    destinationSet.remove("B");
+  
+    let count:number = 0;
+    let values:string[] = [];
+
+    let linkedIter:LinkedIterator<string> = destinationSet.Iterator();
+    for (; linkedIter.hasNext(); ) {
+      const s:string = linkedIter._next();
+      values[count] = s;
+      count = count + 1;
+    }
+    expect (count).toEqual(2);
+    expect (destinationSet.contains("C")).toEqual(true);
+    expect (values[0]).toEqual("C");
+    expect (values[1]).toEqual("A");
   });
 
   it("Test clear", function() {
@@ -205,6 +231,19 @@ describe("Test LinkedHashSet functionality", function() {
     petStoreSet1.clear ();
     expect (petStoreSet1.size ()).toEqual(0);
     expect (petStoreSet1.isEmpty ()).toEqual(true);
+  });
+
+  it("Test hash remove", function() {
+    const petStoreSet1:LinkedHashSet<PetStoreProduct> = new LinkedHashSet<PetStoreProduct> ();
+
+    petStoreSet1.add (product1);
+    petStoreSet1.add (product2);
+    petStoreSet1.add (product3);
+    expect (petStoreSet1.size ()).toEqual(3);
+    expect (petStoreSet1.isEmpty ()).toEqual(false);
+    petStoreSet1.remove (product2);
+    expect (petStoreSet1.size ()).toEqual(2);
+    expect (petStoreSet1.isEmpty ()).toEqual(false);
   });
 
   it("Test contains", function() {

--- a/spec/TestLinkedHashSet.spec.ts
+++ b/spec/TestLinkedHashSet.spec.ts
@@ -186,7 +186,7 @@ describe("Test LinkedHashSet functionality", function() {
     expect (values[2]).toEqual("A");
   });
 
-  it("Test remove LinkedHashSet entry success", function() {
+  it("Test remove entry success", function() {
     // makes new list unorder.. it uses set. see initializeElements() 
     const sourceSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>());
     expect (sourceSet.add ("A")).toEqual(true);
@@ -210,7 +210,7 @@ describe("Test LinkedHashSet functionality", function() {
     expect (values[1]).toEqual("C");
   });
 
-  it("Test remove LinkedHashSet entry failure", function() {
+  it("Test remove entry failure", function() {
     // makes new list unorder.. it uses set. see initializeElements() 
     const sourceSet:LinkedHashSet<string> = new LinkedHashSet<string>(new AllFieldHashable<string>());
     expect (sourceSet.add ("A")).toEqual(true);

--- a/src/HashSet.ts
+++ b/src/HashSet.ts
@@ -36,28 +36,9 @@ export class HashSet<K> implements JSet<K> {
   private datastore:HashMap<K,number> = null;
   private hashMethods:Hashable<K>;
 
-  constructor(iHash:Hashable<K> = AllFieldHashable.instance, private initialElements:ImmutableCollection<K> = null, private iInitialCapacity:number=20, private iLoadFactor:number=0.75, private linkedHashMap?:LinkedHashMap<K,any>) {
+  constructor(iHash:Hashable<K> = AllFieldHashable.instance, private initialElements:ImmutableCollection<K> = null, private iInitialCapacity:number=20, private iLoadFactor:number=0.75) {
     this.hashMethods = iHash;
-    // check if this class will be used for linkedHashSet 
-    if (linkedHashMap !== null && linkedHashMap !== undefined)
-      // using LinkedHashSet
-      if (initialElements !== null) {  
-        // initial elements were sent in need to deal with them.. 
-        let linked:LinkedHashMap<K,any> = new LinkedHashMap<K,any>();
-        const iter:Iterator<K> = initialElements[Symbol.iterator]();
-        let tmp:IteratorResult<K>;
-
-        tmp = iter.next();
-        while (tmp.value !== null && tmp.value !== undefined) {
-            linked.put(tmp.value, 1);
-            tmp = iter.next();
-        }  
-        
-        linkedHashMap.initializeElements(linked);
-        this.datastore = linkedHashMap;
-      } else this.datastore = linkedHashMap;  // using LinkedHashSet without initial elements sent in.. 
-    else this.datastore = new HashMap<K,number>(this.hashMethods, null, iInitialCapacity, iLoadFactor);  // do the default
-
+    this.datastore = new HashMap<K,number>(this.hashMethods, null, iInitialCapacity, iLoadFactor);
     if ((initialElements !== null) && (initialElements !== undefined)){
       for (const iter = initialElements.iterator(); iter.hasNext(); ) {
         const t:K = iter.next ();
@@ -75,10 +56,6 @@ export class HashSet<K> implements JSet<K> {
      const t:K = iter.next();
      consumer.accept(t);
    }
-  }
-
-  public getDataStore(): HashMap<K,number> {
-    return this.datastore;
   }
 
   /**

--- a/src/LinkedHashMap.ts
+++ b/src/LinkedHashMap.ts
@@ -74,6 +74,23 @@ export class LinkedHashMap<K, V> extends HashMap<K, V> {
     }
 
     /**
+     * This override alters behavior of superclass remove method.
+     * @param {V} key key value
+     */
+    public remove (key:K) : V {
+        let result:V = super.remove(key);
+        if (result === null || result === undefined) 
+          return null;  // not there dont proceed further
+
+        for (let e: LinkedEntry<K,V> = this.header.after; e !== this.header; e = e.after) 
+            if (key === e.getKey()) {
+                e.remove();
+                return e.getValue();
+            }
+        return null;
+    }
+
+    /**
      * Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
      * @param key key with which the specified value is to be associated
      */
@@ -158,7 +175,7 @@ export class LinkedEntry<K,V> extends HashMapEntry<K,V> {
     /**
      * Removes this entry from the linked list.
      */
-    private remove () : void {
+    public remove () : void {
         this.before.after = this.after;
         this.after.before = this.before;
     }

--- a/src/LinkedHashSet.ts
+++ b/src/LinkedHashSet.ts
@@ -32,7 +32,7 @@ export class LinkedHashSet<K> extends HashSet<K> {
     }
 
     /**
-     * Initializes the chain before any entries are inserted into the map.
+     * Initializes the chain before any entries are inserted.
      */
     private initChain () : void {
         this.header = new LinkedEntry<K>(null);
@@ -73,7 +73,7 @@ export class LinkedHashSet<K> extends HashSet<K> {
      */
     public remove (value:K) : boolean {
         let result:boolean = super.remove(value);
-        if (result = false) 
+        if (result === false) 
           return false;  // not there dont proceed further
 
         let linkedIter:LinkedIterator<K> = this.Iterator();
@@ -81,10 +81,10 @@ export class LinkedHashSet<K> extends HashSet<K> {
            const val:LinkedEntry<K> = linkedIter.next();
            if (val.equals(value) === true) {
                val.remove();
-               break;
+               return true;
            }
         }
-        
+        return false;
     }
 
     private createEntry (value:K) : boolean {

--- a/src/LinkedHashSet.ts
+++ b/src/LinkedHashSet.ts
@@ -9,7 +9,7 @@ import {AllFieldHashable} from "./AllFieldHashable";
 import {Hashable} from "./Hashable";
 import {ImmutableSet} from "./ImmutableSet";
 import {HashSet} from "./HashSet";
-import {LinkedHashMap, KeyIterator} from "./LinkedHashMap";
+import {JIterator} from "./JIterator";
 
 /**
  * Hash table and linked-list implementation of the Set interface with predictable iteration order. 
@@ -18,20 +18,181 @@ import {LinkedHashMap, KeyIterator} from "./LinkedHashMap";
  */
 export class LinkedHashSet<K> extends HashSet<K> {
 
+    // The head of the doubly linked list.
+    private header: LinkedEntry<K>;
+
     /*
-    * Constructs an empty insertion-ordered LinkedHashSet instance with the default
+    * Constructs an empty insertion-ordered Linked instance with the default
     * initial capacity (20-from super class) and load factor (0.75).
     */
-    constructor (iHash:Hashable<K> = AllFieldHashable.instance, private initElements:ImmutableSet<K> = null, private iInitialCapacityLinked:number=20, private iLoadFactorLinked:number=0.75) {
-        super(iHash, initElements, iInitialCapacityLinked, iLoadFactorLinked, new LinkedHashMap<K,any>(iHash, null, iInitialCapacityLinked, iLoadFactorLinked));
+    constructor (iHash:Hashable<K> = AllFieldHashable.instance, private initialElementsLinked:ImmutableSet<K> = null, private iInitialCapacityLinked:number=20, private iLoadFactorLinked:number=0.75) {
+        super(iHash, null, iInitialCapacityLinked, iLoadFactorLinked);
+        this.initChain();
+        this.initializeElements(initialElementsLinked);
     }
 
-    /*
-    * Java style iterator retrieves hash set values by insertion order.. values here are the keys in the map
-    */
-    public newKeyIterator () : KeyIterator<K,any> {
-        let map:LinkedHashMap<K,any> = <LinkedHashMap<K,any>> this.getDataStore();
-        return map.newKeyIterator();
+    /**
+     * Initializes the chain before any entries are inserted into the map.
+     */
+    private initChain () : void {
+        this.header = new LinkedEntry<K>(null);
+        // make circular
+        this.header.before = this.header.after = this.header;
     }
 
+    /**
+     * Use collection and add to LinkedEntry and super HashSet
+     * @param elements collection to populate
+     */
+    public initializeElements(elements:ImmutableSet<K>) : void {
+        // makes new list unorder.. it uses set..
+        if ((elements !== null) && (elements !== undefined)) {
+            for (const iter = elements.iterator(); iter.hasNext(); ) {
+                const val:K = iter.next ();
+                this.add (val);
+            }
+        }
+    }
+
+    /**
+     * This override alters behavior of superclass add method. It causes newly allocated entry
+     * to get inserted at the end of the linked list.
+     * @param {V} value value
+     */
+    public add (value:K) : boolean {
+        let result:boolean = super.add(value); 
+        if (result === false) 
+          return false;  // avoid inserting duplicate
+
+        return this.createEntry(value);
+    }
+
+    /**
+     * This override alters behavior of superclass remove method.
+     * @param {V} value value
+     */
+    public remove (value:K) : boolean {
+        let result:boolean = super.remove(value);
+        if (result = false) 
+          return false;  // not there dont proceed further
+
+        let linkedIter:LinkedIterator<K> = this.Iterator();
+        for (; linkedIter.hasNext(); ) {
+           const val:LinkedEntry<K> = linkedIter.next();
+           if (val.equals(value) === true) {
+               val.remove();
+               break;
+           }
+        }
+        
+    }
+
+    private createEntry (value:K) : boolean {
+        let e:LinkedEntry<K> = new LinkedEntry<K>(value);
+        e.addBefore(this.header);
+        return true;
+    }
+
+    public clear () : void {
+        super.clear();
+        this.header.before = this.header.after = this.header;
+    }
+
+    /**
+     * Java style iterator retrieves hash set values by insertion order.
+     */
+    public Iterator () : LinkedIterator<K> {
+        let iter:LinkedIterator<K> = new LinkedIterator<K>(this);
+        return iter;
+    }
+
+    public getHeader() : LinkedEntry<K>{
+        return this.header;
+    }
+}
+
+/**
+ * LinkedEntry entry class
+ */
+export class LinkedEntry<K> {
+
+    // These fields comprise the doubly linked list used for iteration.
+    public before: LinkedEntry<K>;
+    public after: LinkedEntry<K>;
+    private value: K;
+
+    constructor (value: K) {
+        this.value = value;
+    }
+
+    /**
+     * Removes this entry from the linked list.
+     */
+    public remove () : void {
+        this.before.after = this.after;
+        this.after.before = this.before;
+    }
+
+    public getValue(): K {
+        return this.value;
+    }
+
+    /**
+     * Inserts this entry before the specified existing entry in the list.
+     * @param existingEntry existing entry
+     */
+    public addBefore (existingEntry: LinkedEntry<K>) : void {
+        this.after = existingEntry;
+        this.before = existingEntry.before;
+        this.before.after = this;
+        this.after.before = this;
+    }
+
+    public equals (o: any) {
+      if (o === undefined || o === null) {
+         return false;
+      }
+      if (JSON.stringify(o) === JSON.stringify(this.value))
+        return true;
+      return false;
+    }
+}
+
+/* Java style iterator */
+export class LinkedIterator<K> implements JIterator<LinkedEntry<K>> {
+    private header:LinkedEntry<K>;
+    private next_Entry:LinkedEntry<K>;
+    private lastReturned:LinkedEntry<K>;
+
+    constructor (linkedSet:LinkedHashSet<K>) {
+        this.header = linkedSet.getHeader();
+        this.next_Entry = linkedSet.getHeader().after;
+        this.lastReturned = null;
+    }
+
+    public next () : LinkedEntry<K> {
+       return this.nextEntry();
+    }
+
+    public _next () : K {
+        return this.next().getValue();
+    }
+
+    public hasNext () : boolean {
+        return this.next_Entry !== this.header;
+    }
+
+    private nextEntry () : LinkedEntry<K> {
+        if(this.check() === false)
+          return null;
+        let e:LinkedEntry<K> = this.lastReturned = this.next_Entry;
+        this.next_Entry = e.after;
+        return e;
+    }
+
+    private check () : boolean {
+        if(this.next_Entry === this.header)
+          return false;
+        return true;
+    }
 }


### PR DESCRIPTION
Revised without touching HashSet constructor. A bit more cleaner implementation with added remove method from previous version and more test coverage. 